### PR TITLE
Allow nullable fields in change-object-status response

### DIFF
--- a/src/Events/Labels.php
+++ b/src/Events/Labels.php
@@ -10,17 +10,17 @@ class Labels
     public $own;
 
     /**
-     * @var LabelAndType
+     * @var LabelAndType|null
      */
     public $parent;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $section;
 
     /**
-     * @var Entrance
+     * @var Entrance|null
      */
     public $entrance;
 


### PR DESCRIPTION
After calling `\Seatsio\Events\Events::book()` for bookable table we gat exception
```
JSON property "parent" in class "Seatsio\Events\Labels" must not be NULL
```
in `vendor/netresearch/jsonmapper/src/JsonMapper.php at line 199`

According docs (https://docs.seats.io/docs/api-custom-object-status#section-response) `parents`, `section` and `entrance` fields are not always returned.
This PR make those fields nullable