### PR TITLE
Add missing parameter supportsBestAvailable in \Seatsio\Events\Events class

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -17,6 +17,10 @@ class Event
      */
     public $bookWholeTables;
     /**
+     * @var boolean
+     */
+    public $supportsBestAvailable;
+    /**
      * @var ForSaleConfig
      */
     public $forSaleConfig;

--- a/tests/Events/CreateEventTest.php
+++ b/tests/Events/CreateEventTest.php
@@ -18,6 +18,7 @@ class CreateEventTest extends SeatsioClientTest
         self::assertNotNull($event->id);
         self::assertEquals($chart->key, $event->chartKey);
         self::assertFalse($event->bookWholeTables);
+        self::assertFalse($event->supportsBestAvailable);
         self::assertNotNull($event->createdOn);
         self::assertNull($event->forSaleConfig);
         self::assertNull($event->updatedOn);

--- a/tests/Events/RetrieveEventTest.php
+++ b/tests/Events/RetrieveEventTest.php
@@ -18,6 +18,7 @@ class RetrieveEventTest extends SeatsioClientTest
         self::assertEquals($event->id, $retrievedEvent->id);
         self::assertEquals($chart->key, $retrievedEvent->chartKey);
         self::assertFalse($retrievedEvent->bookWholeTables);
+        self::assertFalse($retrievedEvent->supportsBestAvailable);
         self::assertEquals($event->createdOn, $retrievedEvent->createdOn);
         self::assertNull($retrievedEvent->forSaleConfig);
         self::assertNull($retrievedEvent->updatedOn);


### PR DESCRIPTION
Hi,

According to the documentation https://docs.seats.io/docs/api-retrieve-an-event we shoud have a parameter named **supportsBestAvailable** in` \Seatsio\Events\Events`, which is actually missing.

This PR fix that. 