### PR TITLE
Prevent a PHP notice when fetching an event report for a non-existing item

### DIFF
--- a/src/EventReports/EventReports.php
+++ b/src/EventReports/EventReports.php
@@ -145,6 +145,9 @@ class EventReports
         if ($filter === null) {
             return $result;
         }
+        if (!isset($result[$filter])) {
+            return [];
+        }
         return $result[$filter];
     }
 


### PR DESCRIPTION
I'm trying to get seat counts by category key for categories retrieved with retrievePublishedVersion, but for some categories (assuming those that have no result) I get an undefined index notice.

Simplified example:

```
$chartKey = 'achartkey';
$eventKey = 'someeventkey';
$chartVersion = $this->getClient()->charts->retrievePublishedVersion($chartKey);
foreach ($chartVersion->categories->list as $category) {
    echo "get count for cat {$category->key}\n";
    $result = $this->getClient()->eventReports->byCategoryKey($eventKey, $category->key);
    echo "- count = {$count}<br>";
}
```

Result:

```
get count for cat 14
- count = 1495
get count for cat 19
- count = 163
get count for cat 22

Notice: Undefined offset: 22 in /src/vendor/seatsio/seatsio-php/src/EventReports/EventReports.php on line 148
- count = 0
```