### PR TITLE
Added chart validation methods

### DIFF
--- a/src/Accounts/Accounts.php
+++ b/src/Accounts/Accounts.php
@@ -28,4 +28,16 @@ class Accounts
         return \GuzzleHttp\json_decode($res->getBody());
     }
 
+    /**
+   * @param $key string
+   * @param $value string
+   * @return void
+   */
+  public function updateSetting ($key, $value) {
+    $request = new \stdClass();
+    $request->key = $key;
+    $request->value = $value;
+    $this->client->post('/accounts/me/settings', ['json' => $request]);
+  }
+
 }

--- a/src/Accounts/ChartValidationSettings.php
+++ b/src/Accounts/ChartValidationSettings.php
@@ -19,4 +19,14 @@ class ChartValidationSettings
      */
     public $VALIDATE_UNLABELED_OBJECTS;
 
+    /**
+     * @var string
+     */
+    public $VALIDATE_FOCAL_POINT;
+
+    /**
+     * @var string
+     */
+    public $VALIDATE_OBJECT_TYPES_PER_CATEGORY;
+
 }

--- a/src/Charts/Charts.php
+++ b/src/Charts/Charts.php
@@ -191,6 +191,26 @@ class Charts
 
     /**
      * @param $key string
+     * @return object
+     */
+    public function validatePublishedVersion($key)
+    {
+        $res = $this->client->post('/charts/' . $key . '/version/published/actions/validate');
+         return \GuzzleHttp\json_decode($res->getBody());
+    }
+
+    /**
+     * @param $key string
+     * @return object
+     */
+    public function validateDraftVersion($key)
+    {
+        $res = $this->client->post('/charts/' . $key . '/version/draft/actions/validate');
+         return \GuzzleHttp\json_decode($res->getBody());
+    }
+
+    /**
+     * @param $key string
      * @return StreamInterface
      */
     public function retrieveDraftVersionThumbnail($key)

--- a/tests/Accounts/RetrieveMyAccountTest.php
+++ b/tests/Accounts/RetrieveMyAccountTest.php
@@ -21,5 +21,7 @@ class RetrieveMyAccountTest extends SeatsioClientTest
         self::assertEquals("ERROR", $account->settings->chartValidation->VALIDATE_DUPLICATE_LABELS);
         self::assertEquals("ERROR", $account->settings->chartValidation->VALIDATE_OBJECTS_WITHOUT_CATEGORIES);
         self::assertEquals("ERROR", $account->settings->chartValidation->VALIDATE_UNLABELED_OBJECTS);
+        self::assertEquals("OFF", $account->settings->chartValidation->VALIDATE_FOCAL_POINT);
+        self::assertEquals("OFF", $account->settings->chartValidation->VALIDATE_OBJECT_TYPES_PER_CATEGORY);
     }
 }

--- a/tests/Accounts/UpdateChartValidationSettingsTest.php
+++ b/tests/Accounts/UpdateChartValidationSettingsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Seatsio\Accounts;
+
+use Seatsio\SeatsioClientTest;
+
+class UpdateSetting extends SeatsioClientTest
+{
+    public function test()
+    {
+
+        $this->seatsioClient->accounts->updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING');
+        $this->seatsioClient->accounts->updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'ERROR');
+
+        $account = $this->seatsioClient->accounts->retrieveMyAccount();
+        self::assertEquals("WARNING", $account->settings->chartValidation->VALIDATE_DUPLICATE_LABELS);
+        self::assertEquals("ERROR", $account->settings->chartValidation->VALIDATE_OBJECTS_WITHOUT_CATEGORIES);
+        self::assertEquals("ERROR", $account->settings->chartValidation->VALIDATE_UNLABELED_OBJECTS);
+        self::assertEquals("OFF", $account->settings->chartValidation->VALIDATE_FOCAL_POINT);
+        self::assertEquals("ERROR", $account->settings->chartValidation->VALIDATE_OBJECT_TYPES_PER_CATEGORY);
+    }
+}

--- a/tests/Charts/validateChartTest.php
+++ b/tests/Charts/validateChartTest.php
@@ -10,9 +10,9 @@ class ValidateChartTest extends SeatsioClientTest
     {
         $chartKey = $this->createTestChartWithErrors();
 
-        $validationErrors = $this->seatsioClient->charts->validatePublishedVersion($chartKey);
+        $validationRes = $this->seatsioClient->charts->validatePublishedVersion($chartKey);
 
-        $errors = \Functional\map($validationErrors->errors, function($error) { return $error->validatorKey; });
-        self::assertEquals(['VALIDATE_UNLABELED_OBJECTS', 'VALIDATE_DUPLICATE_LABELS', 'VALIDATE_OBJECTS_WITHOUT_CATEGORIES'], $errors, '', 0.0, 10, true);
+        self::assertEmpty($validationRes->warnings);
+        self::assertEquals(['VALIDATE_UNLABELED_OBJECTS', 'VALIDATE_DUPLICATE_LABELS', 'VALIDATE_OBJECTS_WITHOUT_CATEGORIES'], $validationRes->errors, '', 0.0, 10, true);
     }
 }

--- a/tests/Charts/validateChartTest.php
+++ b/tests/Charts/validateChartTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Seatsio\Charts;
+
+use Seatsio\SeatsioClientTest;
+
+class ValidateChartTest extends SeatsioClientTest
+{
+    public function testValidatePublishedVersion()
+    {
+        $chartKey = $this->createTestChartWithErrors();
+
+        $validationErrors = $this->seatsioClient->charts->validatePublishedVersion($chartKey);
+
+        $errors = \Functional\map($validationErrors->errors, function($error) { return $error->validatorKey; });
+        self::assertEquals(['VALIDATE_UNLABELED_OBJECTS', 'VALIDATE_DUPLICATE_LABELS', 'VALIDATE_OBJECTS_WITHOUT_CATEGORIES'], $errors, '', 0.0, 10, true);
+    }
+}

--- a/tests/Charts/validateChartTest.php
+++ b/tests/Charts/validateChartTest.php
@@ -15,4 +15,21 @@ class ValidateChartTest extends SeatsioClientTest
         self::assertEmpty($validationRes->warnings);
         self::assertEquals(['VALIDATE_UNLABELED_OBJECTS', 'VALIDATE_DUPLICATE_LABELS', 'VALIDATE_OBJECTS_WITHOUT_CATEGORIES'], $validationRes->errors, '', 0.0, 10, true);
     }
+
+    public function testValidateDraftVersion() {
+       $this->seatsioClient->accounts->updateSetting('VALIDATE_DUPLICATE_LABELS', 'WARNING');
+       $this->seatsioClient->accounts->updateSetting('VALIDATE_UNLABELED_OBJECTS', 'WARNING');
+       $this->seatsioClient->accounts->updateSetting('VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'WARNING');
+       $this->seatsioClient->accounts->updateSetting('VALIDATE_FOCAL_POINT', 'WARNING');
+       $this->seatsioClient->accounts->updateSetting('VALIDATE_OBJECT_TYPES_PER_CATEGORY', 'WARNING');
+
+       $chartKey = $this->createTestChartWithErrors();
+       $this->seatsioClient->events->create($chartKey);
+       $this->seatsioClient->charts->update($chartKey, 'New name');
+
+       $validationRes = $this->seatsioClient->charts->validateDraftVersion($chartKey);
+
+       self::assertEmpty($validationRes->errors);
+       self::assertEquals(['VALIDATE_UNLABELED_OBJECTS', 'VALIDATE_DUPLICATE_LABELS', 'VALIDATE_OBJECTS_WITHOUT_CATEGORIES', 'VALIDATE_FOCAL_POINT', 'VALIDATE_OBJECT_TYPES_PER_CATEGORY'], $validationRes->warnings, '', 0.0, 10, true);
+    }
 }

--- a/tests/SeatsioClientTest.php
+++ b/tests/SeatsioClientTest.php
@@ -55,6 +55,11 @@ class SeatsioClientTest extends PHPUnit_Framework_TestCase
         return $this->createTestChartFromFile('sampleChartWithSections.json');
     }
 
+    protected function createTestChartWithErrors()
+    {
+        return $this->createTestChartFromFile('sampleChartWithErrors.json');
+    }
+
     private function createTestChartFromFile($file)
     {
         $client = new Client();

--- a/tests/sampleChartWithErrors.json
+++ b/tests/sampleChartWithErrors.json
@@ -1,0 +1,444 @@
+{
+  "name": "Sample chart",
+  "tablesLabelCounter": 3,
+  "uuidCounter": 369,
+  "categories": {
+    "list": [
+      {
+        "label": "Cat1",
+        "color": "#87A9CD",
+        "accessible": false,
+        "key": 9
+      },
+      {
+        "label": "Cat2",
+        "color": "#5E42ED",
+        "accessible": false,
+        "key": 10
+      }
+    ],
+    "maxCategoryKey": 10
+  },
+  "version": 17,
+  "venueType": "ROWS_WITHOUT_SECTIONS",
+  "showAllButtons": false,
+  "sectionScaleFactor": 100,
+  "subChart": {
+    "height": 95,
+    "width": 442,
+    "tables": [],
+    "texts": [],
+    "rows": [
+      {
+        "label": "A",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 9,
+            "label": "1",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid288"
+          },
+          {
+            "x": 171.94,
+            "y": 9,
+            "label": "1",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid289"
+          },
+          {
+            "x": 191.94,
+            "y": 9,
+            "label": "?",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid290"
+          },
+          {
+            "x": 211.94,
+            "y": 9,
+            "label": "4",
+            "uuid": "uuid291"
+          },
+          {
+            "x": 231.94,
+            "y": 9,
+            "label": "5",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid292"
+          },
+          {
+            "x": 251.94,
+            "y": 9,
+            "label": "6",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid293"
+          },
+          {
+            "x": 271.94,
+            "y": 9,
+            "label": "7",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid294"
+          },
+          {
+            "x": 291.94,
+            "y": 9,
+            "label": "8",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid295"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid297"
+      },
+      {
+        "label": "B",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 33,
+            "label": "1",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid298"
+          },
+          {
+            "x": 171.94,
+            "y": 33,
+            "label": "2",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid299"
+          },
+          {
+            "x": 191.94,
+            "y": 33,
+            "label": "3",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid300"
+          },
+          {
+            "x": 211.94,
+            "y": 33,
+            "label": "4",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid301"
+          },
+          {
+            "x": 231.94,
+            "y": 33,
+            "label": "5",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid302"
+          },
+          {
+            "x": 251.94,
+            "y": 33,
+            "label": "6",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid303"
+          },
+          {
+            "x": 271.94,
+            "y": 33,
+            "label": "7",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid304"
+          },
+          {
+            "x": 291.94,
+            "y": 33,
+            "label": "8",
+            "categoryLabel": "Cat1",
+            "categoryAccessible": false,
+            "categoryKey": 9,
+            "uuid": "uuid305"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid307"
+      },
+      {
+        "label": "C",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 57,
+            "label": "1",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid308"
+          },
+          {
+            "x": 171.94,
+            "y": 57,
+            "label": "2",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid309"
+          },
+          {
+            "x": 191.94,
+            "y": 57,
+            "label": "3",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid310"
+          },
+          {
+            "x": 211.94,
+            "y": 57,
+            "label": "4",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid311"
+          },
+          {
+            "x": 231.94,
+            "y": 57,
+            "label": "5",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid312"
+          },
+          {
+            "x": 251.94,
+            "y": 57,
+            "label": "6",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid313"
+          },
+          {
+            "x": 271.94,
+            "y": 57,
+            "label": "7",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid314"
+          },
+          {
+            "x": 291.94,
+            "y": 57,
+            "label": "8",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid315"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid317"
+      },
+      {
+        "label": "D",
+        "seatLabeling": {
+          "algoName": "SimpleNumbers",
+          "startAtIndex": 0,
+          "isInverted": false
+        },
+        "objectLabeling": {
+          "algoName": "SimpleLettersUppercase",
+          "prefix": "",
+          "startAtIndex": 0
+        },
+        "seats": [
+          {
+            "x": 151.94,
+            "y": 81,
+            "label": "1",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid318"
+          },
+          {
+            "x": 171.94,
+            "y": 81,
+            "label": "2",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid319"
+          },
+          {
+            "x": 191.94,
+            "y": 81,
+            "label": "3",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid320"
+          },
+          {
+            "x": 211.94,
+            "y": 81,
+            "label": "4",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid321"
+          },
+          {
+            "x": 231.94,
+            "y": 81,
+            "label": "5",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid322"
+          },
+          {
+            "x": 251.94,
+            "y": 81,
+            "label": "6",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid323"
+          },
+          {
+            "x": 271.94,
+            "y": 81,
+            "label": "7",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid324"
+          },
+          {
+            "x": 291.94,
+            "y": 81,
+            "label": "8",
+            "categoryLabel": "Cat2",
+            "categoryAccessible": false,
+            "categoryKey": 10,
+            "uuid": "uuid325"
+          }
+        ],
+        "curve": 0,
+        "chairSpacing": 4,
+        "objectType": "row",
+        "uuid": "uuid327"
+      }
+    ],
+    "shapes": [],
+    "booths": [],
+    "generalAdmissionAreas": [
+      {
+        "categoryLabel": "Cat1",
+        "categoryKey": 9,
+        "capacity": 100,
+        "label": "GA1",
+        "labelSize": 24,
+        "labelShown": true,
+        "labelHorizontalOffset": 0,
+        "labelVerticalOffset": 0,
+        "objectType": "generalAdmission",
+        "uuid": "uuid368",
+        "type": "circle",
+        "center": {
+          "x": 53.22,
+          "y": 48.89
+        },
+        "rotationAngle": 0,
+        "radius1": 52.222222222222626,
+        "radius2": 45.55555555555566
+      },
+      {
+        "categoryLabel": "Cat2",
+        "categoryKey": 10,
+        "capacity": 100,
+        "label": "34",
+        "labelSize": 24,
+        "labelShown": true,
+        "labelHorizontalOffset": 0,
+        "labelVerticalOffset": 0,
+        "objectType": "generalAdmission",
+        "uuid": "uuid369",
+        "type": "circle",
+        "center": {
+          "x": 389.22,
+          "y": 48.89
+        },
+        "rotationAngle": 0,
+        "radius1": 52.222222222222626,
+        "radius2": 45.55555555555566
+      }
+    ],
+    "sections": [],
+    "snapOffset": {
+      "x": 0.06,
+      "y": 3
+    }
+  }
+}


### PR DESCRIPTION
Added chart validation methods. 

It seems like we don't have a method to update account settings in the PHP client and by default `'VALIDATE_UNLABELED_OBJECTS', 'VALIDATE_DUPLICATE_LABELS', 'VALIDATE_OBJECTS_WITHOUT_CATEGORIES'`are set to error, and the other two are off. So I couldn't really add a test for the draft version (because with errors, you can't publish then create a draft). Should I add a method to update settings to the PHP client as well? 