### PR TITLE
properly instantiate SeatsioException when no requestId is present

### DIFF
--- a/src/SeatsioException.php
+++ b/src/SeatsioException.php
@@ -2,6 +2,7 @@
 
 namespace Seatsio;
 
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
@@ -52,10 +53,10 @@ class SeatsioException extends RuntimeException
     {
         $contentType = $response->getHeaderLine("content-type");
         if (strpos($contentType, 'application/json') !== false) {
-            $json = \GuzzleHttp\json_decode($response->getBody());
+            $json = Utils::jsonDecode($response->getBody());
             $mapper = SeatsioJsonMapper::create();
             $errors = $mapper->mapArray($json->errors, array(), 'Seatsio\ApiError');
-            return ["messages" => $json->messages, "errors" => $errors, "requestId" => $json->requestId];
+            return ["messages" => $json->messages, "errors" => $errors, "requestId" => $json->requestId ?? null];
         }
         return ["messages" => [], "errors" => [], "requestId" => null];
     }

--- a/tests/SeatsioExceptionTest.php
+++ b/tests/SeatsioExceptionTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Seatsio;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class SeatsioExceptionTest extends SeatsioClientTest
+{
+
+    public function testCanInstantiateSeatsioExceptionWithoutRequestId()
+    {
+        $request = new DummyRequest();
+        $response = new DummyResponse(
+            "application/json",
+            "{\"errors\": [], \"messages\":[]}"
+        );
+        $exception = new SeatsioException($request, $response);
+        self::assertNull($exception->requestId);
+    }
+}
+
+
+class DummyRequest implements RequestInterface
+{
+
+    public function __construct()
+    {
+    }
+
+    public function getProtocolVersion()
+    {
+    }
+
+    public function withProtocolVersion($version)
+    {
+    }
+
+    public function getHeaders()
+    {
+    }
+
+    public function hasHeader($name)
+    {
+    }
+
+    public function getHeader($name)
+    {
+    }
+
+    public function getHeaderLine($name)
+    {
+    }
+
+    public function withHeader($name, $value)
+    {
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+    }
+
+    public function withoutHeader($name)
+    {
+    }
+
+    public function getBody()
+    {
+    }
+
+    public function withBody(StreamInterface $body)
+    {
+    }
+
+    public function getRequestTarget()
+    {
+    }
+
+    public function withRequestTarget($requestTarget)
+    {
+    }
+
+    public function getMethod()
+    {
+    }
+
+    public function withMethod($method)
+    {
+    }
+
+    public function getUri()
+    {
+    }
+
+    public function withUri(UriInterface $uri, $preserveHost = false)
+    {
+    }
+}
+
+class DummyResponse implements ResponseInterface
+{
+
+
+    private $contentType;
+    private $body;
+
+    public function __construct(string $contentType, string $body)
+    {
+        $this->contentType = $contentType;
+        $this->body = $body;
+    }
+
+    public function getProtocolVersion()
+    {
+    }
+
+    public function withProtocolVersion($version)
+    {
+    }
+
+    public function getHeaders()
+    {
+    }
+
+    public function hasHeader($name)
+    {
+    }
+
+    public function getHeader($name)
+    {
+    }
+
+    public function getHeaderLine($name)
+    {
+        if ($name === "content-type") {
+            return $this->contentType;
+        }
+        return null;
+    }
+
+    public function withHeader($name, $value)
+    {
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+    }
+
+    public function withoutHeader($name)
+    {
+    }
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    public function withBody(StreamInterface $body)
+    {
+    }
+
+    public function getStatusCode()
+    {
+    }
+
+    public function withStatus($code, $reasonPhrase = '')
+    {
+    }
+
+    public function getReasonPhrase()
+    {
+    }
+}


### PR DESCRIPTION
It is possible that seats.io API does not return a request id in some rare cases (500 eg?)
The PHP lib does not handle this correctly, and spits out an exception _while instantiating SeatsioException_, thereby hiding the original cause omnomnom. 
This PR fixes that. 