### PR TITLE
Simplify release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           node-version: 20
       - name: Install dependencies and run release script
-        run: yarn add -D -E zx@8.1.4 semver@7.6.3 && yarn zx ./release.mjs -v $VERSION_TO_BUMP
+        run: |
+          yarn add -D -E zx@8.1.4 semver@7.6.3
+          yarn zx ./release.mjs -v $VERSION_TO_BUMP
         env:
           VERSION_TO_BUMP: ${{ inputs.versionToBump }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install dependencies and run release script
-        run: |
-          yarn add -D -E zx@8.1.4 semver@7.6.3
-          yarn zx ./release.mjs -v $VERSION_TO_BUMP
+      - name: Install dependencies
+        run: yarn add -D -E zx@8.1.4 semver@7.6.3
+      - name: Run release script  
+        run: yarn zx ./release.mjs -v $VERSION_TO_BUMP
         env:
           VERSION_TO_BUMP: ${{ inputs.versionToBump }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn add -D -E zx@8.1.4 semver@7.6.3
       - name: Run release script  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - id: install-zx
-        run: npm i -g zx
-      - id: install-semver-tool
-        run: |
-          wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
-          chmod +x /usr/local/bin/semver
-      - run: zx ./release.mjs -v $VERSION_TO_BUMP
+      - name: Install dependencies and run release script
+        run: yarn add -D -E zx@8.1.4 semver@7.6.3 && yarn zx ./release.mjs -v $VERSION_TO_BUMP
         env:
           VERSION_TO_BUMP: ${{ inputs.versionToBump }}
           GH_TOKEN: ${{ github.token }}

--- a/release.mjs
+++ b/release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env zx
 
 /*
-* Script to release the seats.io java lib.
+* Script to release the seats.io php lib.
 *   - changes the version number in README.md
 *   - changes the version number in build.gradle
 *   - creates the release in Gihub (using gh cli)
@@ -10,15 +10,15 @@
 * Prerequisites:
 *   - zx installed (https://github.com/google/zx)
 *   - gh cli installed (https://cli.github.com/)
-*   - semver cli installed (https://github.com/fsaintjacques/semver-tool)
 *
 * Usage:
-*   zx ./release.mjs -v major/minor -n "release notes"
+*   yarn zx ./release.mjs -v major/minor -n "release notes"
 * */
 
 // don't output the commands themselves
 $.verbose = false
 
+const semver = require('semver')
 const versionToBump = getVersionToBump()
 const latestReleaseTag = await fetchLatestReleasedVersionNumber()
 
@@ -44,7 +44,7 @@ async function fetchLatestReleasedVersionNumber() {
 }
 
 async function determineNextVersionNumber(previous) {
-    return (await $`semver bump ${versionToBump} ${previous}`).stdout.trim()
+    return semver.inc(previous, versionToBump)
 }
 
 async function getCurrentCommitHash() {


### PR DESCRIPTION
This PR changes the release script to install `zx` and `semver` during build, without keeping `package.json` and `yarn.lock` files. This pattern is intended for use across libraries that otherwise do not depend on NPM packages.