### PR TITLE
Remove update chart key for event

### DIFF
--- a/src/Events/Events.php
+++ b/src/Events/Events.php
@@ -145,10 +145,6 @@ class Events
     {
         $request = new stdClass();
 
-        if ($params->chartKey !== null) {
-            $request->chartKey = $params->chartKey;
-        }
-
         if ($params->eventKey !== null) {
             $request->eventKey = $params->eventKey;
         }

--- a/src/Events/UpdateEventParams.php
+++ b/src/Events/UpdateEventParams.php
@@ -5,11 +5,6 @@ namespace Seatsio\Events;
 class UpdateEventParams extends EventParams
 {
     /**
-     * @var string
-     */
-    public $chartKey;
-
-    /**
      * @var bool
      */
     public $isInThePast;

--- a/tests/Events/UpdateEventTest.php
+++ b/tests/Events/UpdateEventTest.php
@@ -11,19 +11,6 @@ use stdClass;
 class UpdateEventTest extends SeatsioClientTest
 {
 
-    public function testUpdateChartKey()
-    {
-        $chart1 = $this->seatsioClient->charts->create();
-        $chart2 = $this->seatsioClient->charts->create();
-        $event = $this->seatsioClient->events->create($chart1->key);
-
-        $this->seatsioClient->events->update($event->key, UpdateEventParams::create()->setChartKey($chart2->key));
-
-        $retrievedEvent = $this->seatsioClient->events->retrieve($event->key);
-        self::assertEquals($chart2->key, $retrievedEvent->chartKey);
-        self::assertNotNull($retrievedEvent->updatedOn);
-    }
-
     public function testUpdateIsInThePast()
     {
         $chart = $this->seatsioClient->charts->create();


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `UpdateEventParams`.