### PR TITLE
declare all instance variables on ObjectProperties class 

### DIFF
--- a/src/Events/Events.php
+++ b/src/Events/Events.php
@@ -565,7 +565,7 @@ class Events
             }
             return array_map(function ($object) {
                 if ($object instanceof ObjectProperties) {
-                    return $object;
+                    return ["objectId" => $object->objectId];
                 }
                 if (is_string($object)) {
                     return ["objectId" => $object];

--- a/src/Events/Events.php
+++ b/src/Events/Events.php
@@ -565,7 +565,7 @@ class Events
             }
             return array_map(function ($object) {
                 if ($object instanceof ObjectProperties) {
-                    return ["objectId" => $object->objectId];
+                    return $object->toArray();
                 }
                 if (is_string($object)) {
                     return ["objectId" => $object];

--- a/src/Events/ObjectProperties.php
+++ b/src/Events/ObjectProperties.php
@@ -8,6 +8,19 @@ class ObjectProperties
      * @var string
      */
     public $objectId;
+    /**
+     * @var string
+     */
+    public $ticketType;
+    /**
+     * @var int
+     */
+    public $quantity;
+    /**
+     * @var array
+     */
+    public $extraData;
+
 
     public function __construct(string $objectId)
     {

--- a/src/Events/ObjectProperties.php
+++ b/src/Events/ObjectProperties.php
@@ -44,4 +44,19 @@ class ObjectProperties
         $this->extraData = $extraData;
         return $this;
     }
+
+    public function toArray()
+    {
+        $result = ["objectId" => $this->objectId];
+        if ($this->ticketType !== null) {
+            $result["ticketType"] = $this->ticketType;
+        }
+        if ($this->quantity !== null) {
+            $result["quantity"] = $this->quantity;
+        }
+        if($this->extraData !== null) {
+            $result["extraData"] = $this->extraData;
+        }
+        return $result;
+    }
 }

--- a/tests/Workspaces/ListActiveWorkspacesTest.php
+++ b/tests/Workspaces/ListActiveWorkspacesTest.php
@@ -20,7 +20,7 @@ class ListActiveWorkspacesTest extends SeatsioClientTest
             return $workspace->name;
         });
 
-        self::assertEquals(["ws3", "ws1", "Default workspace"], array_values($workspaceNames));
+        self::assertEquals(["ws3", "ws1", "Production workspace"], array_values($workspaceNames));
     }
 
     public function test_filter()

--- a/tests/Workspaces/ListWorkspacesTest.php
+++ b/tests/Workspaces/ListWorkspacesTest.php
@@ -20,7 +20,7 @@ class ListWorkspacesTest extends SeatsioClientTest
             return $workspace->name;
         });
 
-        self::assertEquals(["ws3", "ws2", "ws1", "Default workspace"], array_values($workspaceNames));
+        self::assertEquals(["ws3", "ws2", "ws1", "Production workspace"], array_values($workspaceNames));
     }
 
     public function test_filter()


### PR DESCRIPTION
declare variables in ObjectProperties to prevent 'property declared dynamically' warnings. 
See https://github.com/seatsio/seatsio-php/issues/138