### PR TITLE
distinct exception type thrown when best available objects not found

### DIFF
--- a/src/BestAvailableObjectsNotFoundException.php
+++ b/src/BestAvailableObjectsNotFoundException.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Seatsio\Events;
+namespace Seatsio;
 
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Seatsio\SeatsioException;
 
 class BestAvailableObjectsNotFoundException extends SeatsioException
 {

--- a/src/BestAvailableObjectsNotFoundException.php
+++ b/src/BestAvailableObjectsNotFoundException.php
@@ -4,12 +4,11 @@ namespace Seatsio;
 
 
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class BestAvailableObjectsNotFoundException extends SeatsioException
 {
-    public function __construct(RequestInterface $request, ResponseInterface $response, array $parsedResponseInfo, string $message)
+    public function __construct(RequestInterface $request,  array $parsedResponseInfo, string $message)
     {
-        parent::__construct($request, $response, $parsedResponseInfo, $message);
+        parent::__construct($request, $parsedResponseInfo, $message);
     }
 }

--- a/src/BestAvailableObjectsNotFoundException.php
+++ b/src/BestAvailableObjectsNotFoundException.php
@@ -7,8 +7,8 @@ use Psr\Http\Message\RequestInterface;
 
 class BestAvailableObjectsNotFoundException extends SeatsioException
 {
-    public function __construct(RequestInterface $request,  array $parsedResponseInfo, string $message)
+    public function __construct(RequestInterface $request, array $parsedResponse, string $message)
     {
-        parent::__construct($request, $parsedResponseInfo, $message);
+        parent::__construct($request, $parsedResponse, $message);
     }
 }

--- a/src/Events/BestAvailableObjectsNotFoundException.php
+++ b/src/Events/BestAvailableObjectsNotFoundException.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace Seatsio;
+namespace Seatsio\Events;
+
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Seatsio\SeatsioException;
 
-class RateLimitExceededException extends SeatsioException
+class BestAvailableObjectsNotFoundException extends SeatsioException
 {
     public function __construct(RequestInterface $request, ResponseInterface $response, array $parsedResponseInfo, string $message)
     {

--- a/src/RateLimitExceededException.php
+++ b/src/RateLimitExceededException.php
@@ -6,8 +6,8 @@ use Psr\Http\Message\RequestInterface;
 
 class RateLimitExceededException extends SeatsioException
 {
-    public function __construct(RequestInterface $request,array $parsedResponseInfo, string $message)
+    public function __construct(RequestInterface $request, array $parsedResponse, string $message)
     {
-        parent::__construct($request, $parsedResponseInfo, $message);
+        parent::__construct($request, $parsedResponse, $message);
     }
 }

--- a/src/RateLimitExceededException.php
+++ b/src/RateLimitExceededException.php
@@ -3,12 +3,11 @@
 namespace Seatsio;
 
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class RateLimitExceededException extends SeatsioException
 {
-    public function __construct(RequestInterface $request, ResponseInterface $response, array $parsedResponseInfo, string $message)
+    public function __construct(RequestInterface $request,array $parsedResponseInfo, string $message)
     {
-        parent::__construct($request, $response, $parsedResponseInfo, $message);
+        parent::__construct($request, $parsedResponseInfo, $message);
     }
 }

--- a/src/SeatsioClient.php
+++ b/src/SeatsioClient.php
@@ -118,10 +118,7 @@ class SeatsioClient
                         if ($code < 400) {
                             return $response;
                         }
-                        if ($code == 429) {
-                            throw new RateLimitExceededException($request, $response);
-                        }
-                        throw new SeatsioException($request, $response);
+                        throw SeatsioException::from($request, $response);
                     }
                 );
             };

--- a/src/SeatsioException.php
+++ b/src/SeatsioException.php
@@ -25,14 +25,14 @@ class SeatsioException extends RuntimeException
         $parsedResponse = self::extractInfo($response);
         $message = self::message($request, $response, $parsedResponse['messages']);
         if ($code == 429) {
-            return new RateLimitExceededException($request, $response, $parsedResponse, $message);
+            return new RateLimitExceededException($request, $parsedResponse, $message);
         } else if (self::isBestAvailableObjectsNotFound($parsedResponse['errors'])) {
-            throw new BestAvailableObjectsNotFoundException($request, $response, $parsedResponse, $message);
+            throw new BestAvailableObjectsNotFoundException($request, $parsedResponse, $message);
         }
-        return new SeatsioException($request, $response, $parsedResponse, $message);
+        return new SeatsioException($request, $parsedResponse, $message);
     }
 
-    public function __construct(RequestInterface $request, ResponseInterface $response, array $info, string $message)
+    public function __construct(RequestInterface $request, array $info, string $message)
     {
         parent::__construct($message);
         $this->errors = $info['errors'];

--- a/src/SeatsioException.php
+++ b/src/SeatsioException.php
@@ -5,7 +5,6 @@ namespace Seatsio;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
-use Seatsio\Events\BestAvailableObjectsNotFoundException;
 
 class SeatsioException extends RuntimeException
 {

--- a/src/SeatsioException.php
+++ b/src/SeatsioException.php
@@ -32,11 +32,11 @@ class SeatsioException extends RuntimeException
         return new SeatsioException($request, $parsedResponse, $message);
     }
 
-    public function __construct(RequestInterface $request, array $info, string $message)
+    public function __construct(RequestInterface $request, array $parsedResponse, string $message)
     {
         parent::__construct($message);
-        $this->errors = $info['errors'];
-        $this->requestId = $info['requestId'];
+        $this->errors = $parsedResponse['errors'];
+        $this->requestId = $parsedResponse['requestId'];
     }
 
     private static function message($request, $response, $messages)

--- a/src/SeatsioException.php
+++ b/src/SeatsioException.php
@@ -19,6 +19,15 @@ class SeatsioException extends RuntimeException
      */
     public $requestId;
 
+    public static function from(RequestInterface $request, ResponseInterface $response): SeatsioException
+    {
+        $code = $response->getStatusCode();
+        if ($code == 429) {
+            return new RateLimitExceededException($request, $response);
+        }
+        return new SeatsioException($request, $response);
+    }
+
     public function __construct(RequestInterface $request, ResponseInterface $response)
     {
         $info = self::extractInfo($response);

--- a/src/SeatsioException.php
+++ b/src/SeatsioException.php
@@ -5,6 +5,7 @@ namespace Seatsio;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
+use Seatsio\Events\BestAvailableObjectsNotFoundException;
 
 class SeatsioException extends RuntimeException
 {
@@ -22,19 +23,21 @@ class SeatsioException extends RuntimeException
     public static function from(RequestInterface $request, ResponseInterface $response): SeatsioException
     {
         $code = $response->getStatusCode();
+        $parsedResponse = self::extractInfo($response);
+        $message = self::message($request, $response, $parsedResponse['messages']);
         if ($code == 429) {
-            return new RateLimitExceededException($request, $response);
+            return new RateLimitExceededException($request, $response, $parsedResponse, $message);
+        } else if (self::isBestAvailableObjectsNotFound($parsedResponse['errors'])) {
+            throw new BestAvailableObjectsNotFoundException($request, $response, $parsedResponse, $message);
         }
-        return new SeatsioException($request, $response);
+        return new SeatsioException($request, $response, $parsedResponse, $message);
     }
 
-    public function __construct(RequestInterface $request, ResponseInterface $response)
+    public function __construct(RequestInterface $request, ResponseInterface $response, array $info, string $message)
     {
-        $info = self::extractInfo($response);
-        $requestId = $info['requestId'];
-        parent::__construct(self::message($request, $response, $info['messages']));
+        parent::__construct($message);
         $this->errors = $info['errors'];
-        $this->requestId = $requestId;
+        $this->requestId = $info['requestId'];
     }
 
     private static function message($request, $response, $messages)
@@ -54,15 +57,30 @@ class SeatsioException extends RuntimeException
         }
     }
 
-    private static function extractInfo($response)
+    private static function extractInfo($response): array
     {
         $contentType = $response->getHeaderLine("content-type");
-        if (strpos($contentType, 'application/json') !== false) {
+        if (str_contains($contentType, 'application/json')) {
             $json = GuzzleResponseDecoder::decodeToObject($response);
             $mapper = SeatsioJsonMapper::create();
             $errors = $mapper->mapArray($json->errors, array(), 'Seatsio\ApiError');
             return ["messages" => $json->messages, "errors" => $errors, "requestId" => $json->requestId ?? null];
         }
         return ["messages" => [], "errors" => [], "requestId" => null];
+    }
+
+    private static function isBestAvailableObjectsNotFound($errors): bool
+    {
+        if (!is_array($errors) || empty($errors)) {
+            return false;
+        }
+        foreach ($errors as $error) {
+            if (is_object($error) && property_exists($error, 'code')) {
+                if ($error->code === 'BEST_AVAILABLE_OBJECTS_NOT_FOUND') {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/tests/Events/ChangeBestAvailableObjectStatusTest.php
+++ b/tests/Events/ChangeBestAvailableObjectStatusTest.php
@@ -4,6 +4,7 @@ namespace Seatsio\Events;
 
 use Seatsio\Common\IDs;
 use Seatsio\SeatsioClientTest;
+use Seatsio\SeatsioException;
 
 class ChangeBestAvailableObjectStatusTest extends SeatsioClientTest
 {
@@ -202,5 +203,33 @@ class ChangeBestAvailableObjectStatusTest extends SeatsioClientTest
 
         self::assertTrue($bestAvailableObjects->nextToEachOther);
         self::assertEquals(["A-6", "A-7", "A-8"], $bestAvailableObjects->objects);
+    }
+
+    public function testNotFoundThrowsBestAvailableObjectsNotFoundException()
+    {
+        $chartKey = $this->createTestChart();
+        $event = $this->seatsioClient->events->create($chartKey);
+
+        try
+        {
+            $this->seatsioClient->events->changeBestAvailableObjectStatus($event->key, (new BestAvailableParams())->setNumber(3000), "lolzor");
+            self::fail("expected exception");
+        }  catch (BestAvailableObjectsNotFoundException $exception) {
+            self::assertInstanceOf(BestAvailableObjectsNotFoundException::class, $exception);
+            self::assertEquals("Best available objects not found", $exception->getMessage());
+        }
+
+    }
+
+    public function testNormalSeatsioExceptionIfEventNotFound()
+    {
+        try
+        {
+            $this->seatsioClient->events->changeBestAvailableObjectStatus("unexistingEvent", (new BestAvailableParams())->setNumber(3), "lolzor");
+            self::fail("expected exception");
+        }  catch (SeatsioException $exception) {
+            self::assertNotInstanceOf(BestAvailableObjectsNotFoundException::class, $exception);
+        }
+
     }
 }

--- a/tests/Events/ChangeBestAvailableObjectStatusTest.php
+++ b/tests/Events/ChangeBestAvailableObjectStatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Seatsio\Events;
 
+use Seatsio\BestAvailableObjectsNotFoundException;
 use Seatsio\Common\IDs;
 use Seatsio\SeatsioClientTest;
 use Seatsio\SeatsioException;

--- a/tests/SeatsioExceptionTest.php
+++ b/tests/SeatsioExceptionTest.php
@@ -19,7 +19,7 @@ class SeatsioExceptionTest extends SeatsioClientTest
             ["Content-Type" => "application/json"],
             "{\"errors\": [], \"messages\":[]}"
         );
-        $exception = new SeatsioException($request, $response);
+        $exception = SeatsioException::from($request, $response);
         self::assertNull($exception->requestId);
         self::assertStringStartsWith("GET http://dummy.uri resulted in a `400 Bad Request` response.", $exception->getMessage());
     }


### PR DESCRIPTION
Instead of throwing a generic `SeatsioException` (which is thrown in many cases, eg no focal point, event not found, etc), we now throw a `BestAvailableObjectsNotFoundException` (subclass of SeatsioException) to make it easier to handle this common specific case.