### PR TITLE
Move event to a new chart copy

### DIFF
--- a/src/Events/Events.php
+++ b/src/Events/Events.php
@@ -565,6 +565,14 @@ class Events
         return $mapper->map($json, new BestAvailableObjects());
     }
 
+    public function moveEventToNewChartCopy(string $eventKey): Event
+    {
+        $res = $this->client->post(UriTemplate::expand('/events/{key}/actions/move-to-new-chart-copy', array("key" => $eventKey)));
+        $json = GuzzleResponseDecoder::decodeToObject($res);
+        $mapper = SeatsioJsonMapper::create();
+        return $mapper->map($json, new Event());
+    }
+
     private static function normalizeObjects($objectOrObjects): array
     {
         if (is_array($objectOrObjects)) {

--- a/tests/Events/MoveEventToNewChartCopyTest.php
+++ b/tests/Events/MoveEventToNewChartCopyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Seatsio\Events;
+
+use Seatsio\SeatsioClientTest;
+
+class MoveEventToNewChartCopyTest extends SeatsioClientTest
+{
+    public function testEventIsMovedToNewChartCopy()
+    {
+        $chart = $this->seatsioClient->charts->create();
+        $event = $this->seatsioClient->events->create($chart->key);
+
+        $movedEvent = $this->seatsioClient->events->moveEventToNewChartCopy($event->key);
+
+        self::assertNotEquals($event->chartKey, $movedEvent->chartKey);
+        self::assertEquals($event->key, $movedEvent->key);
+    }
+}


### PR DESCRIPTION
Creates a new copy of the chart the event belongs to, and moves the event to that chart.