### PR TITLE
Update dependency versions to be more lenient

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
       update-types:
         - minor
         - patch
+    versioning-strategy: increase

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "require": {
     "php": ">=8.3.0",
-    "guzzlehttp/guzzle": "^7.10",
-    "guzzlehttp/uri-template": "^v1.0",
-    "netresearch/jsonmapper": "^5.0",
-    "halaxa/json-machine": "^1.2"
+    "guzzlehttp/guzzle": "^7.10.4",
+    "guzzlehttp/uri-template": "^v1.0.6",
+    "netresearch/jsonmapper": "^5.0.1",
+    "halaxa/json-machine": "^1.2.6"
   },
   "require-dev": {
     "brianium/paratest": "v7.16.1",

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "require": {
     "php": ">=8.3.0",
-    "guzzlehttp/guzzle": "7.10.4",
-    "guzzlehttp/uri-template": "v1.0.6",
-    "netresearch/jsonmapper": "5.0.1",
-    "halaxa/json-machine": "1.2.6"
+    "guzzlehttp/guzzle": "^7.10",
+    "guzzlehttp/uri-template": "^v1.0",
+    "netresearch/jsonmapper": "^5.0",
+    "halaxa/json-machine": "^1.2"
   },
   "require-dev": {
     "brianium/paratest": "v7.16.1",


### PR DESCRIPTION
https://github.com/seatsio/seatsio-php/issues/182 makes a good point: our dependency are currently pinned at exact versions, which does not allow our customers to use security patched versions before we upgrade.

So I made the versions more lenient. E.g. for Guzzle we now allow v7.10 or newer, but not v8.

Dependabot will still bump the dependency versions every month. 