### PR TITLE
Convenience: Wrap channels replace payload with array_values.

### DIFF
--- a/src/Events/Channels.php
+++ b/src/Events/Channels.php
@@ -182,9 +182,9 @@ class Channels
     public function replace(string $eventKey, array $channels): void
     {
         $request = new stdClass();
-        $request->channels = array_map(function ($channel) {
+        $request->channels = array_values(array_map(function ($channel) {
             return $channel->toArray();
-        }, $channels);
+        }, $channels));
         $this->client->post(UriTemplate::expand('/events/{key}/channels/replace', array("key" => $eventKey)), ['json' => $request]);
     }
 }

--- a/tests/Events/Channels/ReplaceChannelsTest.php
+++ b/tests/Events/Channels/ReplaceChannelsTest.php
@@ -29,4 +29,24 @@ class ReplaceChannelsTest extends SeatsioClientTest
         ], $channels);
     }
 
+    public function testReplaceWithAssociativeArrayKeys()
+    {
+        $chartKey = $this->createTestChart();
+        $event = $this->seatsioClient->events->create($chartKey);
+
+        $this->seatsioClient->events->channels->replace($event->key, [
+            "channelKey1" => (new ChannelCreationParams())->setChannelKey("channelKey1")->setName("channel 1")->setColor("#FF0000")->setIndex(1)->setObjects(["A-1", "A-2"])->setAreaPlaces(["GA1" => 3]),
+            "channelKey2" => (new ChannelCreationParams())->setChannelKey("channelKey2")->setName("channel 2")->setColor("#00FFFF")->setIndex(2)->setObjects([])
+        ]);
+
+        $retrievedEvent = $this->seatsioClient->events->retrieve($event->key);
+
+        $channels = $retrievedEvent->channels;
+
+        self::assertEquals([
+            new Channel("channelKey1", $channels[0]->id, "channel 1", "#FF0000", 1, ["A-1", "A-2"], ["GA1" => 3]),
+            new Channel("channelKey2", $channels[1]->id, "channel 2", "#00FFFF", 2, [], [])
+        ], $channels);
+    }
+
 }


### PR DESCRIPTION
Ensures the channels array is sent as a JSON array rather than an object when keys are non-sequential.

This avoids this error:
`Uncaught Seatsio\SeatsioException: #/channels: expected type: JSONArray, found: JSONObject`